### PR TITLE
Fix plane info crash

### DIFF
--- a/libs/raknet/RakNet.vcxproj
+++ b/libs/raknet/RakNet.vcxproj
@@ -112,7 +112,7 @@
       <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
       <Optimization>Disabled</Optimization>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <UseFullPaths>false</UseFullPaths>
       <PreprocessorDefinitions>WIN32;_RAKNET_DLL;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;CMAKE_INTDIR="Debug";raknet_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -487,19 +487,35 @@ void BLOCK::Refresh (SLONG PlayerNum, BOOL StyleType)
                   else                                       f=&FontSmallBlack;
 
                   Bitmap.PrintAt (Table.Values[0+c*Table.AnzColums], *f, TEC_FONT_LEFT, ClientArea+XY(0,  (c-Page)*26), Bitmap.Size);
-                  Bitmap.PrintAt (Table.Values[1+c*Table.AnzColums], *f, TEC_FONT_LEFT, ClientArea+XY(123, (c-Page)*26), Bitmap.Size);
+                  Bitmap.PrintAt (Table.Values[1+c*Table.AnzColums], *f, TEC_FONT_RIGHT, ClientArea+XY(145, (c-Page)*26), ClientArea + XY(175, (c - Page) * 26+10));
 
                   Bitmap.PrintAt (Table.Values[3+c*Table.AnzColums], *f, TEC_FONT_LEFT, ClientArea+XY(0, (c-Page)*26+10), Bitmap.Size);
                   
                   // Add additional information to plane list
-                  CPlane& qPlane = qPlayer.Planes[c];
-                  // check if plane name is correct, some are mixed up
-                  if (qPlayer.Planes[c].Name == Table.Values[0 + c * Table.AnzColums])
-                  { 
-                      Bitmap.PrintAt(bprintf("%li (%li)", qPlane.MaxPassagiere, qPlane.MaxPassagiereFC), FontSmallGrey, TEC_FONT_LEFT, ClientArea + XY(70, (c - Page) * 26 + 10), Bitmap.Size);
-                      Bitmap.PrintAt(Einheiten[EINH_KM].bString(qPlane.ptReichweite), FontSmallGrey, TEC_FONT_LEFT, ClientArea + XY(123, (c - Page) * 26 + 10), Bitmap.Size);
+                  for (i = 0, d = 0; i < (SLONG)qPlayer.Planes.AnzEntries(); i++){
+                      if (qPlayer.Planes.IsInAlbum(i)) {
+                          CPlane& qPlane = qPlayer.Planes[i];
+
+		                  // check if plane name is correct, some are mixed up
+		                  if (qPlane.Name == Table.Values[0 + c * Table.AnzColums])
+		                  {
+
+                              XY left = ClientArea + XY(110, (c - Page) * 26);
+                              XY right = ClientArea + XY(143, (c - Page) * 26 + 10);
+
+                              if(BlockTypeB == 6) {
+	                              //Freight
+                                  Bitmap.PrintAt(Einheiten[EINH_T].bString(qPlane.ptPassagiere / 10), FontSmallGrey, TEC_FONT_RIGHT, left, right);
+                              }else if(BlockTypeB == 4) { //Routes
+                                  Bitmap.PrintAt(bprintf("(%li/%li)", qPlane.MaxPassagiere, qPlane.MaxPassagiereFC), FontSmallGrey, TEC_FONT_RIGHT, left, right);
+                              }else{
+                                  Bitmap.PrintAt(bprintf("(%li)", qPlane.MaxPassagiere + qPlane.MaxPassagiereFC), FontSmallGrey, TEC_FONT_RIGHT, left, right);
+                              }
+		                      Bitmap.PrintAt(Einheiten[EINH_KM].bString(qPlane.ptReichweite), FontSmallGrey, TEC_FONT_LEFT, ClientArea + XY(123, (c - Page) * 26 + 10), Bitmap.Size);
+                              break;
+		                  }
+                      }
                   }
-                  
                }
                break;
 

--- a/src/NewgamePopup.cpp
+++ b/src/NewgamePopup.cpp
@@ -29,9 +29,9 @@ extern CJumpingVar<ULONG>   gPhysicalCdRomBitlist;
 extern CJumpingVar<CString> gCDPath;
 
 #ifdef _DEBUG
-char VersionString[] = "VERSION 1.5 DEBUG"; // (pre-release; build 100)";
+char VersionString[] = "VERSION 1.5.1 DEBUG"; // (pre-release; build 100)";
 #else
-char VersionString[] = "VERSION 1.5 PRE-RELEASE"; // (pre-release; build 100)";
+char VersionString[] = "VERSION 1.5.1 PRE-RELEASE"; // (pre-release; build 100)";
 #endif
 
 extern SLONG gLoadGameNumber;

--- a/src/Takeoff.cpp
+++ b/src/Takeoff.cpp
@@ -293,9 +293,11 @@ int main(int argc, char* argv[])
 
 	theApp.InitInstance(argc, argv);
 
+#ifdef SENTRY
     if (!disableSentry) {
 		sentry_close();
     }
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
Plane info crashes due to incorrect accessing of the Planes Album

Also moved and added info in the filofax
![image](https://user-images.githubusercontent.com/7768485/193668540-943aee1b-1134-4c28-a69d-cab4f244fdc5.png)
