### PR TITLE
Adds proper rendering for 4:3 aspect ration

### DIFF
--- a/src/SBLib/source/CBitmap.cpp
+++ b/src/SBLib/source/CBitmap.cpp
@@ -525,8 +525,6 @@ SLONG SB_CPrimaryBitmap::Create(SDL_Renderer **out, SDL_Window *Wnd, unsigned sh
             Hdu.HercPrintf("Unable to lock backbuffer to surface");
             return -1;
         }
-
-        SDL_SetTextureScaleMode(lpTexture, SDL_ScaleModeBest);
     } else {
         Hdu.HercPrintf("Falling back to software presentation");
         lpTexture = nullptr;

--- a/src/Sbbm.cpp
+++ b/src/Sbbm.cpp
@@ -596,7 +596,6 @@ void SBPRIMARYBM::Flip(XY WindowPos, BOOL /*ShowFPS*/) {
 
     // TextOut (0, 20, RGB(0,0,255), RGB(255,255,0), bprintf ("%f FPS", GetFrameRate()));
     // TextOut (0, 32, RGB(0,0,255), RGB(255,255,0), bprintf ("%li Personen", Sim.Persons.GetNumUsed()));
-    PrimaryBm.SetPos(CPoint(WindowPos.x, WindowPos.y));
     Bench.FlipTime.Start();
     PrimaryBm.Flip();
     Bench.FlipTime.Stop();

--- a/src/sbl.h
+++ b/src/sbl.h
@@ -202,8 +202,8 @@ class SB_CPrimaryBitmap : public SB_CBitmapCore {
     virtual ULONG Release(void);
     SLONG Flip(void);
     SLONG Present(void);
+    void SetTarget(XY offset, XY size);
     void SetVSync(BOOL toggle) { SDL_RenderSetVSync(lpDD, toggle); }
-    void SetPos(POINT);
 
     void AssignCursor(SB_CCursor *c) { Cursor = c; }
     SDL_Window *GetPrimarySurface() { return Window; }
@@ -211,6 +211,10 @@ class SB_CPrimaryBitmap : public SB_CBitmapCore {
 
   private:
     void Delete(void);
+
+    
+    XY TargetSize{640,480};
+    XY TargetOffset{0,0};
 
     SDL_Window *Window{};
     SB_CCursor *Cursor{};


### PR DESCRIPTION
The current system doesn't properly render the game at the correct resolution, but rather SDL2 hard converts the resolution (also scaling the cursor)

This is rather inconvenient and also leads to inconsitencies in how the game handles input and rendering - moving away from the SDL2 implementation for scaled rendering unifyies the rendering