### PR TITLE
Removed OptionKeepAspectRatio from UpdateWindow()

### DIFF
--- a/src/GameFrame.cpp
+++ b/src/GameFrame.cpp
@@ -163,7 +163,6 @@ void GameFrame::UpdateWindow() const {
     case (0): // Fullscreen
         SDL_SetWindowSize(m_hWnd, screenWidth, screenHeight);
         SDL_SetWindowFullscreen(m_hWnd, SDL_TRUE);
-        Sim.Options.OptionKeepAspectRatio = 0;
         break;
     case (1): // Windowed
         SDL_SetWindowFullscreen(m_hWnd, 0);
@@ -178,7 +177,6 @@ void GameFrame::UpdateWindow() const {
         SDL_SetWindowBordered(m_hWnd, SDL_FALSE);
         SDL_SetWindowPosition(m_hWnd, 0, 0);
         SDL_SetWindowSize(m_hWnd, screenWidth, screenHeight);
-        Sim.Options.OptionKeepAspectRatio = 0;
         break;
     default:
         hprintf("GameFrame.cpp: Default case should not be reached.");


### PR DESCRIPTION
In the gameframe method UpdateWindow() were some hard coded AspectRatios. Which do reset the set ratio to 0 (stretch) after leaving the options menu.