### PR TITLE
Window mode fix

### DIFF
--- a/src/GameFrame.cpp
+++ b/src/GameFrame.cpp
@@ -165,13 +165,23 @@ void GameFrame::UpdateWindow() const {
         SDL_SetWindowFullscreen(m_hWnd, SDL_TRUE);
         break;
     case (1): // Windowed
-        SDL_SetWindowFullscreen(m_hWnd, 0);
-        SDL_SetWindowResizable(m_hWnd, SDL_TRUE);
-        SDL_SetWindowBordered(m_hWnd, SDL_TRUE);
-        SDL_SetWindowSize(m_hWnd, screenWidth, screenHeight);
-        SDL_GetWindowSize(m_hWnd, &width, &height);
-        SDL_MaximizeWindow(m_hWnd);
-        SDL_SetWindowPosition(m_hWnd, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+        // check if default window size, if so set to MaximizeWindow else set as from last session
+        if (Sim.Options.OptionScreenWindowedWidth == 640 && Sim.Options.OptionScreenWindowedHeight == 480)
+        {
+            SDL_SetWindowFullscreen(m_hWnd, 0);
+            SDL_SetWindowResizable(m_hWnd, SDL_TRUE);
+            SDL_SetWindowBordered(m_hWnd, SDL_TRUE);
+            SDL_SetWindowSize(m_hWnd, screenWidth, screenHeight);
+            SDL_MaximizeWindow(m_hWnd);
+            SDL_SetWindowPosition(m_hWnd, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+        } else {
+            SDL_SetWindowFullscreen(m_hWnd, 0);
+            SDL_SetWindowResizable(m_hWnd, SDL_TRUE);
+            SDL_SetWindowBordered(m_hWnd, SDL_TRUE);
+            SDL_SetWindowSize(m_hWnd, Sim.Options.OptionScreenWindowedWidth, Sim.Options.OptionScreenWindowedHeight);
+            SDL_SetWindowPosition(m_hWnd, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+        }
+
         break;
     case (2): // Borderless Fullscreen
         SDL_SetWindowFullscreen(m_hWnd, SDL_FALSE);
@@ -194,7 +204,9 @@ void GameFrame::UpdateFrameSize() const {
     SLONG screenW = 0, screenH = 0;
     SDL_GetWindowSize(m_hWnd, &screenW, &screenH);
     SDL_RenderSetLogicalSize(lpDD, screenW, screenH);
-
+    // update setting file
+    Sim.Options.OptionScreenWindowedWidth = screenW;
+    Sim.Options.OptionScreenWindowedHeight = screenH;
     if (Sim.Options.OptionKeepAspectRatio == 0) {
         PrimaryBm.PrimaryBm.SetTarget(XY{0, 0}, XY{screenW, screenH});
     } else {
@@ -269,8 +281,9 @@ GameFrame::GameFrame() {
     }
 
     // Base backup screen size - only used in windowed mode
-    SLONG width = 640;
-    SLONG height = 480;
+    SLONG width = Sim.Options.OptionScreenWindowedWidth;
+    SLONG height = Sim.Options.OptionScreenWindowedHeight;
+
 
     if (!static_cast<bool>(bFullscreen) || Sim.Options.OptionFullscreen == 0 || Sim.Options.OptionFullscreen == 2) {
         SDL_DisplayMode DM;

--- a/src/GameFrame.cpp
+++ b/src/GameFrame.cpp
@@ -168,8 +168,10 @@ void GameFrame::UpdateWindow() const {
         SDL_SetWindowFullscreen(m_hWnd, 0);
         SDL_SetWindowResizable(m_hWnd, SDL_TRUE);
         SDL_SetWindowBordered(m_hWnd, SDL_TRUE);
-        SDL_SetWindowSize(m_hWnd, width, height);
-        SDL_SetWindowPosition(m_hWnd, screenWidth / 2 - width / 2, screenHeight / 2 - height / 2);
+        SDL_SetWindowSize(m_hWnd, screenWidth, screenHeight);
+        SDL_GetWindowSize(m_hWnd, &width, &height);
+        SDL_MaximizeWindow(m_hWnd);
+        SDL_SetWindowPosition(m_hWnd, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
         break;
     case (2): // Borderless Fullscreen
         SDL_SetWindowFullscreen(m_hWnd, SDL_FALSE);

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -630,6 +630,10 @@ void Options::OnLButtonDown(UINT /*nFlags*/, CPoint point) {
                 ChangedDisplay = 1;
 
                 Sim.Options.OptionFullscreen++;
+                if (Sim.Options.OptionFullscreen == 1) {
+                    Sim.Options.OptionScreenWindowedWidth = 640;
+                    Sim.Options.OptionScreenWindowedHeight = 480;
+                }
                 if (Sim.Options.OptionFullscreen > 2) {
                     Sim.Options.OptionFullscreen = 0;
                 }

--- a/src/Sim.cpp
+++ b/src/Sim.cpp
@@ -4152,7 +4152,12 @@ void COptions::ReadOptions() {
         if (!reg.ReadRegistryKey_u(OptionRentOfficeMaxAvailable)) {
             OptionRentOfficeMaxAvailable = 3;
         }
-
+        if (!reg.ReadRegistryKey_l(OptionScreenWindowedWidth)) {
+            OptionScreenWindowedWidth = 640; // default window width
+        }
+        if (!reg.ReadRegistryKey_l(OptionScreenWindowedHeight)) {
+            OptionScreenWindowedHeight = 480; // default window height
+        }
         // Falls Setup nicht geladen wurde dann Standard-Parameter initialisieren
         if (!reg.ReadRegistryKey_b(OptionPlanes)) {
             OptionPlanes = TRUE;
@@ -4379,6 +4384,7 @@ void COptions::ReadOptions() {
         if (!reg.ReadRegistryKey_u(Sim.GameSpeed)) {
             Sim.GameSpeed = 30;
         }
+
     }
 }
 
@@ -4407,6 +4413,8 @@ void COptions::WriteOptions() {
 
 
     // Regular
+    reg.WriteRegistryKey_l(OptionScreenWindowedWidth);
+    reg.WriteRegistryKey_l(OptionScreenWindowedHeight);
     reg.WriteRegistryKey_b(OptionPlanes);
     reg.WriteRegistryKey_b(OptionPassengers);
     reg.WriteRegistryKey_l(OptionMusicType);

--- a/src/class.h
+++ b/src/class.h
@@ -2362,6 +2362,8 @@ class COptions {
   public:
     SLONG OptionFullscreen{};
     BOOL OptionKeepAspectRatio{};
+    SLONG OptionScreenWindowedWidth{};
+    SLONG OptionScreenWindowedHeight{};
     BOOL OptionPlanes{};
     BOOL OptionPassengers{};
     SLONG OptionMusicType{};


### PR DESCRIPTION
The Options were extended to save the last set Width and Height of the window. The UpdateWindow function was modified to use this setting if it is set. When changing the view in options from fullscreen or borderless to windowed it reset to a maximized window, by setting the default window size of 640x480. This will trigger the UpdateWindow function to set it to maximized.
Also, the position was changed to use SDL_WINDOWPOS_CENTERED instead of a calculation.