### PR TITLE
made it compatible with Polish files

### DIFF
--- a/src/NewGamePopup.cpp
+++ b/src/NewGamePopup.cpp
@@ -95,20 +95,28 @@ void NewGamePopup::Konstruktor(BOOL /*bHandy*/, SLONG /*PlayerNum*/) {
 #endif
 
     if (Sim.Options.OptionAirport == -1) {
-        if (gLanguage == LANGUAGE_N) {
-            Sim.Options.OptionAirport = Cities.GetIdFromName("Berlijn");
-        } else if (gLanguage == LANGUAGE_F) {
-            Sim.Options.OptionAirport = Cities.GetIdFromName("Paris");
-        } else if (gLanguage == LANGUAGE_I) {
-            Sim.Options.OptionAirport = Cities.GetIdFromName("Roma");
-        } else if (gLanguage == LANGUAGE_O) {
-            Sim.Options.OptionAirport = Cities.GetIdFromName("Madrid");
-        } else if (gLanguage == LANGUAGE_S) {
-            Sim.Options.OptionAirport = Cities.GetIdFromName("Madrid");
-        } else if (gLanguage == LANGUAGE_E) {
-            Sim.Options.OptionAirport = Cities.GetIdFromName("London");
-        } else {
-            Sim.Options.OptionAirport = Cities.GetIdFromName("Berlin");
+        switch (gLanguage) {
+            case LANGUAGE_E:
+                Sim.Options.OptionAirport = Cities.GetIdFromName("Berlin"); // workaround for Polish until properly added
+                break;
+            case LANGUAGE_F:
+                Sim.Options.OptionAirport = Cities.GetIdFromName("Paris");
+                break;
+            case LANGUAGE_P:
+                Sim.Options.OptionAirport = Cities.GetIdFromName("Warszawa");
+                break;
+            case LANGUAGE_N:
+                Sim.Options.OptionAirport = Cities.GetIdFromName("Amsterdam");
+                break;
+            case LANGUAGE_I:
+                Sim.Options.OptionAirport = Cities.GetIdFromName("Roma");
+                break;
+            case LANGUAGE_S:
+            case LANGUAGE_O:
+                Sim.Options.OptionAirport = Cities.GetIdFromName("Madrid");
+                break;
+            default:
+                Sim.Options.OptionAirport = Cities.GetIdFromName("Berlin");
         }
     }
 
@@ -2432,9 +2440,11 @@ void NewGamePopup::OnChar(UINT nChar, UINT nRepCnt, UINT nFlags) {
 
     nChar = KeycodeToUpper(nChar);
 
+    const bool validCharacter = nChar == '-' || nChar == ' ' || (nChar >= 'A' && nChar <= 'Z') || nChar == '\xC4' || nChar == '\xD6' || nChar == '\xDC' || nChar == '.';
+
     if (CursorY != -1 &&
         (PageNum == PAGE_TYPE::SELECT_PLAYER_SINGLEPLAYER || PageNum == PAGE_TYPE::SELECT_PLAYER_CAMPAIGN || PageNum == PAGE_TYPE::SELECT_PLAYER_MULTIPLAYER)) {
-        if (nChar == '-' || nChar == ' ' || (nChar >= 'A' && nChar <= 'Z') || nChar == '\xC4' || nChar == '\xD6' || nChar == '\xDC' || nChar == '.') {
+        if (validCharacter) {
             if (CursorX < 0) {
                 if (nChar != ' ') {
                     Sim.Players.Players[SLONG(CursorY / 2)].Abk.SetAt(CursorX + 3, UBYTE(nChar));
@@ -2463,7 +2473,7 @@ void NewGamePopup::OnChar(UINT nChar, UINT nRepCnt, UINT nFlags) {
             }
         }
     } else if (PageNum == PAGE_TYPE::MULTIPLAYER_CREATE_SESSION) {
-        if (nChar == '-' || nChar == ' ' || (nChar >= 'A' && nChar <= 'Z') || nChar == '\xC4' || nChar == '\xD6' || nChar == '\xDC' || nChar == '.') {
+        if (validCharacter) {
             NetworkSession.SetAt(CursorX, UBYTE(nChar));
             RefreshKlackerField();
 

--- a/src/Sim.cpp
+++ b/src/Sim.cpp
@@ -605,14 +605,31 @@ void SIM::ChooseStartup() {
     Workers.EnsureBerater(BERATERTYP_FLUGZEUG);
 
     if (Options.OptionAirport == -1) {
-        Options.OptionAirport = Cities.GetIdFromName("Berlin");
-        if (gLanguage == LANGUAGE_E) {
-            Options.OptionAirport = Cities.GetIdFromName("London");
-        }
-        if (gLanguage == LANGUAGE_F) {
-            Options.OptionAirport = Cities.GetIdFromName("Paris");
+        switch (gLanguage) {
+            case LANGUAGE_E:
+                Options.OptionAirport = Cities.GetIdFromName("Berlin"); // workaround for Polish until properly added
+                break;
+            case LANGUAGE_F:
+                Options.OptionAirport = Cities.GetIdFromName("Paris");
+                break;
+            case LANGUAGE_P:
+                Options.OptionAirport = Cities.GetIdFromName("Warszawa");
+                break;
+            case LANGUAGE_N:
+                Options.OptionAirport = Cities.GetIdFromName("Amsterdam");
+                break;
+            case LANGUAGE_I:
+                Options.OptionAirport = Cities.GetIdFromName("Roma");
+                break;
+            case LANGUAGE_S:
+            case LANGUAGE_O:
+                Options.OptionAirport = Cities.GetIdFromName("Madrid");
+                break;
+            default:
+                Options.OptionAirport = Cities.GetIdFromName("Berlin");
         }
     }
+
     HomeAirportId = Options.OptionAirport;
 
     if (Difficulty == DIFF_NORMAL) {
@@ -1188,11 +1205,11 @@ void SIM::CreateMissionCities() {
 
     // Default-Städte:
     MissionCities[0] = Cities.GetIdFromNames("R\xEDo de Janeiro", "Rio de Janeiro", NULL);
-    MissionCities[1] = Cities.GetIdFromNames("Nova Iorque", "Nueva York", "New York", NULL);
+    MissionCities[1] = Cities.GetIdFromNames("Nova Iorque", "Nueva York", "New York", "Nowy Jork", NULL);
     MissionCities[2] = Cities.GetIdFromNames("T\xF3quio", "Tokio", "Tokyo", NULL);
     MissionCities[3] = Cities.GetIdFromNames("Deli", "Delhi", "Dill\xED", NULL);
     MissionCities[4] = Cities.GetIdFromNames("Joanesburgo", "Johanesburgo", "Johannesburg", NULL);
-    MissionCities[5] = Cities.GetIdFromNames("Moskau", "Moskou", "Moscovo", "Moscou", "Mosca", "Mosc\xFA", "Moscow", "Moskva", NULL);
+    MissionCities[5] = Cities.GetIdFromNames("Moskau", "Moskou", "Moscovo", "Moscou", "Mosca", "Mosc\xFA", "Moscow", "Moskva", "Moskwa", NULL);
 
     /*if (gLanguage==LANGUAGE_S) MissionCities[0]=Cities.GetIdFromName ("Río de Janeiro");
       else                       MissionCities[0]=Cities.GetIdFromName ("Rio de Janeiro");
@@ -4298,7 +4315,7 @@ void COptions::ReadOptions() {
         }
 #endif
 #ifdef NO_E_VOICES
-        if (gLanguage == LANGUAGE_E &&) {
+        if (gLanguage == LANGUAGE_E) {
             OptionSpeechBubble = TRUE;
             OptionTalking = FALSE;
         }


### PR DESCRIPTION
In NewGamePopup.cpp and Sim.cpp, synced the default starting airports with each other, changed the default airport in English (and "Polnisch! Krank!", I love this original comment xD) to Berlin since it's spelled the same in both languages, changed the Dutch airport to Amsterdam while I'm here.
In NewGamePopup.cpp, in OnChar, deduped the whitelist check by putting it before all ifs.
In Sim.cpp, added Polish spellings of cities for New York, Rio, Tokio mission.

I want to make the Polish translation work with Polish diacritics, which requires small changes in CStdRaum::OnChar, KLACKER::PrintAt, NewGamePopup::OnChar, Options::OnChar, GerToUpper, GerToLower.

However, it requires a rewrite of the input system because currently it receives keys, not characters. To paraphrase myself from Discord: you type a character by pressing RAlt+a. The game receives SDLK_RALT, SDLK_RALT and a. In Polish keyboard, this is ą. In the international US keyboard, it's á.